### PR TITLE
Add registry-url option when setting up node

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ The following inputs can be used as `step.with` keys:
 |---------------------|------------------|-------------------------------------------|
 | `working-directory` | `.`              | The working directory of the action       |
 | `node-version`      | `16`             | The Node.js version that should be set up |
+| `registry-url`      | (empty)          | Optional registry to set up for auth      |
 
 ### Setup Node and Install Dependencies
 
@@ -45,6 +46,7 @@ The following inputs can be used as `step.with` keys:
 |---------------------|------------------|-------------------------------------------|
 | `working-directory` | `.`              | The working directory of the action       |
 | `node-version`      | `16`             | The Node.js version that should be set up |
+| `registry-url`      | (empty)          | Optional registry to set up for auth      |
 
 ### Create a new NPM version
 

--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,9 @@ This action will set up Node.js.
 #### Example
 
 ```yaml
-  - uses: aboutbits/github-actions-node/setup@v1
-    with:
-      node-version: 16
+- uses: aboutbits/github-actions-node/setup@v1
+  with:
+    node-version: 16
 ```
 
 #### Inputs
@@ -21,9 +21,10 @@ This action will set up Node.js.
 The following inputs can be used as `step.with` keys:
 
 | Name                | Required/Default | Description                               |
-|---------------------|------------------|-------------------------------------------|
+| ------------------- | ---------------- | ----------------------------------------- |
 | `working-directory` | `.`              | The working directory of the action       |
 | `node-version`      | `16`             | The Node.js version that should be set up |
+| `registry-url`      | `''`             | Optional registry to set up for auth      |
 
 ### Setup Node and Install Dependencies
 
@@ -32,9 +33,9 @@ This action will set up Node.js and install all NPM dependencies.
 #### Example
 
 ```yaml
-  - uses: aboutbits/github-actions-node/setup-and-install@v1
-    with:
-      node-version: 16
+- uses: aboutbits/github-actions-node/setup-and-install@v1
+  with:
+    node-version: 16
 ```
 
 #### Inputs
@@ -42,9 +43,10 @@ This action will set up Node.js and install all NPM dependencies.
 The following inputs can be used as `step.with` keys:
 
 | Name                | Required/Default | Description                               |
-|---------------------|------------------|-------------------------------------------|
+| ------------------- | ---------------- | ----------------------------------------- |
 | `working-directory` | `.`              | The working directory of the action       |
 | `node-version`      | `16`             | The Node.js version that should be set up |
+| `registry-url`      | `''`             | Optional registry to set up for auth      |
 
 ### Create a new NPM version
 
@@ -53,23 +55,23 @@ This action will set up git, increment the NPM version and push the changes.
 #### Example
 
 ```yaml
-  - uses: aboutbits/github-actions-node/version@v1
-    with:
-      git-user-name: AboutBits
-      git-user-email: info@aboutbits.it
+- uses: aboutbits/github-actions-node/version@v1
+  with:
+    git-user-name: AboutBits
+    git-user-email: info@aboutbits.it
 ```
 
 #### Inputs
 
 The following inputs can be used as `step.with` keys:
 
-| Name                | Required/Default | Description                               |
-|---------------------|------------------|-------------------------------------------|
-| `working-directory` | `.`              | The working directory of the action       |
-| `git-user-name`     | Required         | The name of the git user                  |
-| `git-user-email`    | Required         | The email of the git user                 |
-| `version`           | `patch`          | The version that should be set            |
-| `message`           | `[RELEASE] %s`   | The message of the git commit             |
+| Name                | Required/Default | Description                         |
+| ------------------- | ---------------- | ----------------------------------- |
+| `working-directory` | `.`              | The working directory of the action |
+| `git-user-name`     | Required         | The name of the git user            |
+| `git-user-email`    | Required         | The email of the git user           |
+| `version`           | `patch`          | The version that should be set      |
+| `message`           | `[RELEASE] %s`   | The message of the git commit       |
 
 ## Versioning
 

--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,9 @@ This action will set up Node.js.
 #### Example
 
 ```yaml
-- uses: aboutbits/github-actions-node/setup@v1
-  with:
-    node-version: 16
+  - uses: aboutbits/github-actions-node/setup@v1
+    with:
+      node-version: 16
 ```
 
 #### Inputs
@@ -21,10 +21,9 @@ This action will set up Node.js.
 The following inputs can be used as `step.with` keys:
 
 | Name                | Required/Default | Description                               |
-| ------------------- | ---------------- | ----------------------------------------- |
+|---------------------|------------------|-------------------------------------------|
 | `working-directory` | `.`              | The working directory of the action       |
 | `node-version`      | `16`             | The Node.js version that should be set up |
-| `registry-url`      | `''`             | Optional registry to set up for auth      |
 
 ### Setup Node and Install Dependencies
 
@@ -33,9 +32,9 @@ This action will set up Node.js and install all NPM dependencies.
 #### Example
 
 ```yaml
-- uses: aboutbits/github-actions-node/setup-and-install@v1
-  with:
-    node-version: 16
+  - uses: aboutbits/github-actions-node/setup-and-install@v1
+    with:
+      node-version: 16
 ```
 
 #### Inputs
@@ -43,10 +42,9 @@ This action will set up Node.js and install all NPM dependencies.
 The following inputs can be used as `step.with` keys:
 
 | Name                | Required/Default | Description                               |
-| ------------------- | ---------------- | ----------------------------------------- |
+|---------------------|------------------|-------------------------------------------|
 | `working-directory` | `.`              | The working directory of the action       |
 | `node-version`      | `16`             | The Node.js version that should be set up |
-| `registry-url`      | `''`             | Optional registry to set up for auth      |
 
 ### Create a new NPM version
 
@@ -55,23 +53,23 @@ This action will set up git, increment the NPM version and push the changes.
 #### Example
 
 ```yaml
-- uses: aboutbits/github-actions-node/version@v1
-  with:
-    git-user-name: AboutBits
-    git-user-email: info@aboutbits.it
+  - uses: aboutbits/github-actions-node/version@v1
+    with:
+      git-user-name: AboutBits
+      git-user-email: info@aboutbits.it
 ```
 
 #### Inputs
 
 The following inputs can be used as `step.with` keys:
 
-| Name                | Required/Default | Description                         |
-| ------------------- | ---------------- | ----------------------------------- |
-| `working-directory` | `.`              | The working directory of the action |
-| `git-user-name`     | Required         | The name of the git user            |
-| `git-user-email`    | Required         | The email of the git user           |
-| `version`           | `patch`          | The version that should be set      |
-| `message`           | `[RELEASE] %s`   | The message of the git commit       |
+| Name                | Required/Default | Description                               |
+|---------------------|------------------|-------------------------------------------|
+| `working-directory` | `.`              | The working directory of the action       |
+| `git-user-name`     | Required         | The name of the git user                  |
+| `git-user-email`    | Required         | The email of the git user                 |
+| `version`           | `patch`          | The version that should be set            |
+| `message`           | `[RELEASE] %s`   | The message of the git commit             |
 
 ## Versioning
 

--- a/setup-and-install/action.yml
+++ b/setup-and-install/action.yml
@@ -1,15 +1,19 @@
-name: 'Setup and install dependencies'
+name: "Setup and install dependencies"
 
 inputs:
   working-directory:
-    description: 'The working directory'
+    description: "The working directory"
     required: false
-    default: '.'
+    default: "."
   node-version:
-    description: 'The Node version that should be used for the build'
+    description: "The Node version that should be used for the build"
     required: true
-    default: '16.x'
-  
+    default: "16.x"
+  registry-url:
+    description: "Registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN."
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -19,6 +23,7 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: npm
         cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+        registry-url: ${{ inputs.registry-url }}
     - name: Install dependencies
       working-directory: ${{ inputs.working-directory }}
       run: npm ci

--- a/setup-and-install/action.yml
+++ b/setup-and-install/action.yml
@@ -1,21 +1,21 @@
-name: "Setup and install dependencies"
+name: 'Setup and install dependencies'
 
 inputs:
   working-directory:
-    description: "The working directory"
+    description: 'The working directory'
     required: false
-    default: "."
+    default: '.'
   node-version:
-    description: "The Node version that should be used for the build"
+    description: 'The Node version that should be used for the build'
     required: true
-    default: "16.x"
+    default: '16.x'
   registry-url:
-    description: "Registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN."
+    description: 'Registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.'
     required: false
-    default: ""
+    default: ''
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Set up Node
       uses: actions/setup-node@v3

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -1,17 +1,17 @@
-name: "Setup"
+name: 'Setup'
 
 inputs:
   node-version:
-    description: "The Node version that should be used for the build"
+    description: 'The Node version that should be used for the build'
     required: true
-    default: "16.x"
+    default: '16.x'
   registry-url:
-    description: "Registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN."
+    description: 'Registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.'
     required: false
-    default: ""
+    default: ''
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Set up Node
       uses: actions/setup-node@v3

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -1,15 +1,15 @@
-name: 'Setup'
+name: "Setup"
 
 inputs:
-  working-directory:
-    description: 'The working directory'
-    required: false
-    default: '.'
   node-version:
-    description: 'The Node version that should be used for the build'
+    description: "The Node version that should be used for the build"
     required: true
-    default: '16.x'
-  
+    default: "16.x"
+  registry-url:
+    description: "Registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN."
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -17,3 +17,4 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.registry-url }}


### PR DESCRIPTION
As can be seen in [the readme of the setup-node GitHub action](https://github.com/actions/setup-node), the option `registry-url` needs to be set so that the env variable `NODE_AUTH_TOKEN` is used for authentication.

This PR adds the possibility of passing `registry-url` to `setup-node`